### PR TITLE
Deletion of all Album Quizzes after finishing one of them and increasing top artists and tracks limit

### DIFF
--- a/src/main/java/com/group6/harmoniq/controllers/QuizController.java
+++ b/src/main/java/com/group6/harmoniq/controllers/QuizController.java
@@ -226,7 +226,7 @@ public class QuizController {
             userService.incrementUserAddedSongsLimit(currentUser); //Increment user addedSongsLimit at the end of the quiz
             model.addAttribute("score", score);
             allQuestion.clear();
-            allAlbumQuizzes.remove(quiz);
+            allAlbumQuizzes.clear();
             return "quizzes/quizResult";
         }
     }
@@ -245,7 +245,7 @@ public class QuizController {
 
     @GetMapping("/quizzes/recognitionQuiz/{questionId}")
     public String getRecognitionQuizQuestion(@PathVariable int questionId, Model model, HttpSession session) {
-
+        setCurrentUser(session);
         if (currentRecognitionQuestionIndex < recognitionQuizAnswers.size()) {
             
             Map<String,Object> answer = recognitionQuizAnswers.get(questionId);
@@ -260,7 +260,6 @@ public class QuizController {
             model.addAttribute("questionId", questionId);
             return "quizzes/recognitionQuiz"; // Redirect to the quiz page
         } else {
-            setCurrentUser(session);
             userService.incrementUserQuizCount(currentUser); // Increment user quiz count at the end of the quiz
             userService.incrementUserAddedSongsLimit(currentUser); //Increment user addedSongsLimit at the end of the quiz
             model.addAttribute("score", recognitionScore); // Add score to the model for the result page
@@ -270,12 +269,16 @@ public class QuizController {
    
     @PostMapping("/quizzes/recognitionQuiz/submit")
     public String processRecogntionQuizAnswer(@RequestParam("selectedOption") String selectedOption, @RequestParam("questionId") int questionId, Model model, HttpSession session) {
-
-        if (recognitionQuizAnswers != null && selectedOption.equals((recognitionQuizAnswers.get(questionId)).get("name"))) {
-            recognitionScore++; // Increment score for correct answer
-            model.addAttribute("result", "Correct!");
-        } else {
-            model.addAttribute("result", "Incorrect.");
+        setCurrentUser(session);
+        if (recognitionQuizAnswers != null && currentUser != null) {
+            if (selectedOption.equals((recognitionQuizAnswers.get(questionId)).get("name"))) {
+                userService.updateQuizResults(currentUser, 1, 1);
+                recognitionScore++; // Increment score for correct answer
+                model.addAttribute("result", "Correct!");
+            } else {
+                userService.updateQuizResults(currentUser, 0, 1);
+                model.addAttribute("result", "Incorrect.");
+            }
         }
 
 
@@ -286,7 +289,6 @@ public class QuizController {
         if (currentRecognitionQuestionIndex < recognitionQuizAnswers.size()) {
             return "redirect:/quizzes/recognitionQuiz/" + currentRecognitionQuestionIndex;
         } else {
-            setCurrentUser(session);
             userService.incrementUserQuizCount(currentUser); // Increment user quiz count at the end of the quiz
             userService.incrementUserAddedSongsLimit(currentUser); //Increment user addedSongsLimit at the end of the quiz
             model.addAttribute("score", recognitionScore);

--- a/src/main/java/com/group6/harmoniq/controllers/QuizController.java
+++ b/src/main/java/com/group6/harmoniq/controllers/QuizController.java
@@ -269,18 +269,18 @@ public class QuizController {
    
     @PostMapping("/quizzes/recognitionQuiz/submit")
     public String processRecogntionQuizAnswer(@RequestParam("selectedOption") String selectedOption, @RequestParam("questionId") int questionId, Model model, HttpSession session) {
-        setCurrentUser(session);
-        if (recognitionQuizAnswers != null && currentUser != null) {
-            if (selectedOption.equals((recognitionQuizAnswers.get(questionId)).get("name"))) {
+        if (recognitionQuizAnswers != null && selectedOption.equals((recognitionQuizAnswers.get(questionId)).get("name"))) {
+            recognitionScore++; // Increment score for correct answer
+            if(currentUser != null){
                 userService.updateQuizResults(currentUser, 1, 1);
-                recognitionScore++; // Increment score for correct answer
-                model.addAttribute("result", "Correct!");
-            } else {
-                userService.updateQuizResults(currentUser, 0, 1);
-                model.addAttribute("result", "Incorrect.");
             }
+            model.addAttribute("result", "Correct!");
+        } else {
+            if(currentUser != null){
+                userService.updateQuizResults(currentUser, 0, 1);
+                }
+            model.addAttribute("result", "Incorrect.");
         }
-
 
         currentRecognitionQuestionIndex++; // Move to the next question
 

--- a/src/main/java/com/group6/harmoniq/controllers/QuizController.java
+++ b/src/main/java/com/group6/harmoniq/controllers/QuizController.java
@@ -245,7 +245,6 @@ public class QuizController {
 
     @GetMapping("/quizzes/recognitionQuiz/{questionId}")
     public String getRecognitionQuizQuestion(@PathVariable int questionId, Model model, HttpSession session) {
-        setCurrentUser(session);
         if (currentRecognitionQuestionIndex < recognitionQuizAnswers.size()) {
             
             Map<String,Object> answer = recognitionQuizAnswers.get(questionId);
@@ -260,6 +259,7 @@ public class QuizController {
             model.addAttribute("questionId", questionId);
             return "quizzes/recognitionQuiz"; // Redirect to the quiz page
         } else {
+            setCurrentUser(session);
             userService.incrementUserQuizCount(currentUser); // Increment user quiz count at the end of the quiz
             userService.incrementUserAddedSongsLimit(currentUser); //Increment user addedSongsLimit at the end of the quiz
             model.addAttribute("score", recognitionScore); // Add score to the model for the result page
@@ -289,6 +289,7 @@ public class QuizController {
         if (currentRecognitionQuestionIndex < recognitionQuizAnswers.size()) {
             return "redirect:/quizzes/recognitionQuiz/" + currentRecognitionQuestionIndex;
         } else {
+            setCurrentUser(session);
             userService.incrementUserQuizCount(currentUser); // Increment user quiz count at the end of the quiz
             userService.incrementUserAddedSongsLimit(currentUser); //Increment user addedSongsLimit at the end of the quiz
             model.addAttribute("score", recognitionScore);

--- a/src/main/java/com/group6/harmoniq/controllers/SpotifyController.java
+++ b/src/main/java/com/group6/harmoniq/controllers/SpotifyController.java
@@ -258,7 +258,7 @@ public class SpotifyController {
     private List<Artist> getTopArtists(String accessToken) throws Exception {
 
         // Modify the URL to request top artists (you can adjust the 'limit' parameter)
-        String url = "https://api.spotify.com/v1/me/top/artists?limit=10"; 
+        String url = "https://api.spotify.com/v1/me/top/artists?limit=15"; 
     
         HttpHeaders headers = new HttpHeaders();
         headers.set("Authorization", "Bearer " + accessToken);
@@ -305,7 +305,7 @@ public class SpotifyController {
 
     private List<Track> getTopTracks(String accessToken) throws Exception {
 
-        String url = "https://api.spotify.com/v1/me/top/tracks?limit=10";
+        String url = "https://api.spotify.com/v1/me/top/tracks?limit=15";
 
         HttpHeaders headers = new HttpHeaders();
         headers.set("Authorization", "Bearer " + accessToken);


### PR DESCRIPTION
Currently if someone creates quiz but doesn't plays it, any other user can play it. Implemented feature that deletes all quizzes after user finished one of them. Increased limit for top artists and top tracks in Spotify to 15.